### PR TITLE
fix: resolve ModuleNotFoundError; all 39 tests green; production hardening

### DIFF
--- a/server/citation_research/_cite.py
+++ b/server/citation_research/_cite.py
@@ -19,7 +19,8 @@ def _split_paragraphs(text: str) -> List[str]:
 
 
 def _existing_citations(paragraph: str) -> List[int]:
-    return [int(m.group(1)) for m in re.finditer(r"\[S(\d+)\]", paragraph)]
+    """Return 1-based citation indices, including already-flagged [S# UNVERIFIED] forms."""
+    return [int(m.group(1)) for m in re.finditer(r"\[S(\d+)(?:\s+UNVERIFIED)?\]", paragraph)]
 
 
 def bm25_cite(synthesis: str, sources: List[Dict[str, Any]],
@@ -76,8 +77,10 @@ def bm25_cite(synthesis: str, sources: List[Dict[str, Any]],
                 if cite < 1 or cite > len(sources):
                     continue
                 cite_score = float(scores[cite - 1])
-                if cite_score < verify_threshold:
-                    new_para = new_para.replace(f"[S{cite}]", f"[S{cite} UNVERIFIED]", 1)
+                tag = f"[S{cite}]"
+                if cite_score < verify_threshold and tag in new_para:
+                    # Replace [S#] with [S# UNVERIFIED]; already-flagged tags are no-ops.
+                    new_para = new_para.replace(tag, f"[S{cite} UNVERIFIED]", 1)
                     flagged += 1
             out_paragraphs.append(new_para)
         elif best_score >= insert_threshold:

--- a/server/citation_research/mcp_server.py
+++ b/server/citation_research/mcp_server.py
@@ -33,7 +33,19 @@ _client = DaemonClient()
 
 # Hard confidence gate — not caller-configurable to prevent bypass.
 # Override at deployment time via CITATION_RESEARCH_GATE env variable.
-_HARD_GATE = float(os.environ.get("CITATION_RESEARCH_GATE", "0.90"))
+_env_gate = os.environ.get("CITATION_RESEARCH_GATE", "0.90")
+try:
+    _HARD_GATE = float(_env_gate)
+except ValueError:
+    raise SystemExit(
+        f"CITATION_RESEARCH_GATE={_env_gate!r} is not a valid float. "
+        "Set it to a value in (0, 1], e.g. '0.90'."
+    )
+if not 0.0 < _HARD_GATE <= 1.0:
+    raise SystemExit(
+        f"CITATION_RESEARCH_GATE={_env_gate!r} ({_HARD_GATE}) is out of range. "
+        "Must be in (0, 1], e.g. '0.90'."
+    )
 
 
 def _parse_sources(sources_json: str | None) -> List[Dict[str, Any]]:

--- a/server/pyproject.toml
+++ b/server/pyproject.toml
@@ -43,3 +43,4 @@ include = ["citation_research*"]
 testpaths = ["tests"]
 python_files = ["test_*.py"]
 addopts = "-v"
+pythonpath = [".", "src"]

--- a/server/tests/test_cite.py
+++ b/server/tests/test_cite.py
@@ -149,3 +149,18 @@ def test_bm25_source_list_indexed_from_one(sources):
         f"source_list nums should be 1..{len(sources)}, got {nums}"
     )
 
+
+
+def test_bm25_cite_idempotent():
+    """Second bm25_cite pass on already-flagged synthesis must be a no-op."""
+    synthesis = "Quantum computers use qubits [S1]."
+    sources = [{"url": "u1", "title": "q", "content": "qubit entanglement quantum"}]
+    # threshold above any realistic BM25 score — every citation gets flagged
+    first = bm25_cite(synthesis, sources, verify_threshold=999.0)
+    assert "[S1 UNVERIFIED]" in first["cited_text"]
+    assert first["flagged"] == 1
+
+    # second pass: [S1 UNVERIFIED] must not be re-flagged or double-counted
+    second = bm25_cite(first["cited_text"], sources, verify_threshold=999.0)
+    assert second["cited_text"] == first["cited_text"]
+    assert second["flagged"] == 0


### PR DESCRIPTION
## Summary

Full senior-dev cycle: fix the blocking import error, run all tests to green, perform a production code review, fix all identified bugs.

---

## Changes

### 1. `server/pyproject.toml` — Fix root-cause `ModuleNotFoundError`
Added `pythonpath = [".", "src"]` to `[tool.pytest.ini_options]`.  
pytest was not adding `server/` to `sys.path`, so `import citation_research` failed at collection time. This one-line fix unblocks the entire test suite.

### 2. `server/citation_research/mcp_server.py` — Harden `_HARD_GATE` env-var parsing
**Bug**: `_HARD_GATE = float(os.environ.get("CITATION_RESEARCH_GATE", "0.90"))` had two failure modes:
- Non-numeric value (e.g. `'abc'`) → bare `ValueError` at module import, server silently fails to start.
- Out-of-range value (e.g. `2.0` or `-0.5`) → accepted without error; `2.0` means the confidence gate can never pass (all verifications fail), `-0.5` means it always passes (security bypass).

**Fix**: Wrap in `try/except` and add `0.0 < gate <= 1.0` bounds check; invalid values now raise `SystemExit` with a clear deployment-error message, consistent with the existing FastMCP import guard pattern in the same file.

### 3. `server/citation_research/_cite.py` — Fix `bm25_cite` idempotency
**Bug**: `_existing_citations` matched `[S#]` but not `[S# UNVERIFIED]`. Calling `bm25_cite` twice on an already-processed synthesis re-entered the insert branch, potentially adding duplicate or conflicting citations.

**Fix**:
- Updated regex to `r"\[S(\d+)(?:\s+UNVERIFIED)?\]"` to match both forms.
- Added `tag in new_para` guard in the flagging loop so already-`UNVERIFIED`-flagged tags are no-ops on a second pass.

### 4. `server/tests/test_cite.py` — Add idempotency regression test
Added `test_bm25_cite_idempotent`: verifies that a second `bm25_cite` pass on a synthesis containing `[S# UNVERIFIED]` leaves the text unchanged and reports `flagged=0`.

---

## Test results
```
39 passed in 2.46s
```
All 38 original tests pass; 1 new regression test added.