### PR TITLE
fix(ci): mark workspace safe directory in debian container

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,12 @@ jobs:
       image: golang:1.23-bookworm
     steps:
       - uses: actions/checkout@v4
+      - name: Mark workspace as Git safe directory
+        # Containerised Go builds embed VCS info via `go build`, which
+        # invokes git inside the container. Git refuses (CVE-2022-24765)
+        # when the checkout owner UID differs from the container user —
+        # the failure surfaces as `error obtaining VCS status: exit status 128`.
+        run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
       - name: Test daemon (race detector)
         working-directory: daemon
         run: go test -race ./...


### PR DESCRIPTION
## Summary

- Single failing matrix cell: `go-daemon (debian:12)`. All 14 other jobs (Python 3.10-3.13 × ubuntu 22/24, Go on alpine/ubuntu-22/24/latest, cross-build) pass.
- Root cause: containerised Go builds embed VCS info via `go build`, which invokes git inside the container. Git refuses (CVE-2022-24765 fix, default since 2022) when the checkout owner UID differs from the container user — surfacing as `error obtaining VCS status: exit status 128`.
- Why Alpine job works but Debian one doesn't: `apk add git` on a clean container starts with no global gitconfig; `golang:1.23-bookworm` ships a default gitconfig that triggers the safety check.

## Fix

Add `git config --global --add safe.directory "$GITHUB_WORKSPACE"` step before `go test` / `go build` in the `go-daemon-debian` job. This is the canonical fix used by golang/go's own CI and the pattern recommended by GitHub Actions docs for in-container Go builds.

## Test plan

- [x] Local diff review against the working `go-daemon` and `go-daemon-alpine` jobs to confirm the safe-directory step is the only delta needed.
- [ ] CI run on this PR (Debian job goes green).
- [ ] Merge → main badge flips to green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)